### PR TITLE
Iss72: update intro

### DIFF
--- a/methodes_neurocog/intro.md
+++ b/methodes_neurocog/intro.md
@@ -20,7 +20,13 @@ Ce livre "Méthodes en neurosciences cognitives" présente les principales techn
  * tomographie par émission de positrons,
  * imagerie optique.
 
-Le texte se destine à des lecteurs qui découvrent ces méthodes pour la première fois, et souhaitent acquérir des connaissances théoriques sur les bases physiques et physiologiques de ces techniques de neuroimagerie, ainsi que les principales techniques de traitement d’image et d’analyse statistique qui leur sont associées. Chaque chapitre comporte une série d'exercices, qui incluent des exemples d'applications dans le cadre de projets de recherche en neurosciences cognitives. Plutôt qu'un ouvrage "spécialiste" qui explique tous les détails sur une technique donnée, ce livre vise à présenter l'ensemble des techniques les plus conventionnelles de manière concise, pour que les lecteurs puissent en apprécier les forces et faiblesses, et le type de recherche pour lequel chaque technique est la plus adaptée.
+Le texte se destine à des lecteurs qui découvrent ces méthodes pour la première fois, et souhaitent acquérir des connaissances théoriques sur les bases physiques et physiologiques de ces techniques de neuroimagerie, ainsi que les principales techniques de traitement d’image et d’analyse statistique qui leur sont associées. Chaque chapitre comporte une série d'exercices, qui incluent des exemples d'applications dans le cadre de projets de recherche en neurosciences cognitives.
+
+```{warning}
+Plutôt qu'un ouvrage "spécialiste" qui explique tous les détails sur une technique donnée, ce livre vise à présenter l'ensemble des techniques les plus conventionnelles en neuroscience cognitive de manière concise, pour que les lecteurs puissent en apprécier les forces et faiblesses, et le type de recherche pour lequel chaque technique est la plus adaptée.
+```
+
+## Contributeurs
 
 Ce livre a démarré comme une série de notes pour le cours PSY3018, donné au baccalauréat en neurosciences cognitives du département de psychologie de l'Université de Montréal. Le cours est donné principalement par Dr Pierre Bellec, avec des contributions par les auxiliaires d'enseignement, ainsi que de multiples intervenants supplémentaires. Ce livre bénéficie également du retour constructif des étudiants du cours PSY3018 depuis sa création en 2018. Les contributions générales sont présentées ci-dessous. Des contributions spécifiques sont listées au sein de chaque chapitre.
 
@@ -110,7 +116,8 @@ Ce livre a démarré comme une série de notes pour le cours PSY3018, donné au 
   </tr>
 </table>
 
-Ce livre est dans une large mesure "reproductible": de nombreuses figures sont générées à l'aide de données ouvertes, avec du code qui est intégré dans le libre. Cela est rendu possible grâce aux projets suivants:
+## Remerciements
+Ce livre est dans une large mesure "reproductible": de nombreuses figures sont générées à l'aide de données ouvertes, avec du code qui fait parti du livre. Cette technologie est rendue possible grâce aux projets suivants:
  * [jupyter book](https://jupyterbook.org) est l'outil utilisé pour générer le livre. Ce projet repose lui-même sur l'outil de documentation [sphynx](https://www.sphinx-doc.org).
  * La librairie [nilearn](https://nilearn.github.io/) en [python](https://www.python.org/), notamment pour la partie sur l'IRM structurelle, l'IRM fonctionnelle et les modèles statistiques.
  * La librairie [Dipy](https://dipy.org), notamment pour la partie sur l'IRM de diffusion.
@@ -119,4 +126,4 @@ Ce livre est dans une large mesure "reproductible": de nombreuses figures sont g
  * Le logo provient du site <a href="https://www.vecteezy.com/free-vector/brain">Brain Vectors by Vecteezy</a>
  * Certaines images du livre ont été obtenues sous droits illimités pour diffusion web et limités pour impression (500k copies) via [shutterstock](https://www.shutterstock.com) par P. Bellec.
 
- Les auteurs sont très reconnaissants pour l'énorme travail et la générosité des communautés qui créent et maintiennent toutes ces ressources.
+ Les auteurs sont très reconnaissants pour l'énorme travail et la générosité des communautés qui créent et maintiennent tous ces projets!

--- a/methodes_neurocog/intro.md
+++ b/methodes_neurocog/intro.md
@@ -15,14 +15,14 @@ kernelspec:
 
 # Introduction
 
-Ce texte contient l'ensemble des notes du cours PSY3018 "Méthodes en neurosciences cognitives", donné au baccalauréat en neurosciences cognitives du département de psychologie de l'Université de Montréal. Ce cours présente les principales techniques de neuroimagerie pour étudier la cognition chez l'humain (et l'animal), disposant d'une bonne résolution spatiale:
+Ce livre "Méthodes en neurosciences cognitives" présente les principales techniques de neuroimagerie pour étudier la cognition chez l'humain (et l'animal), disposant d'une bonne résolution spatiale:
  * résonance magnétique (anatomique, fonctionnelle, et de diffusion),
  * tomographie par émission de positrons,
  * imagerie optique.
 
-Le principal objectif d’apprentissage pour ce cours est l’acquisition de connaissances théoriques sur les bases physiques et physiologiques de différentes techniques de neuroimagerie, ainsi que les principales techniques de traitement d’image et d’analyse statistique qui leur sont associées. Le cours présentera aussi comment ces techniques de neuroimagerie sont appliquées dans le cadre de projets de recherche en neurosciences cognitives, et chaque chapitre comporte une série d'exercices.
+Le texte se destine à des lecteurs qui découvrent ces méthodes pour la première fois, et souhaitent acquérir des connaissances théoriques sur les bases physiques et physiologiques de ces techniques de neuroimagerie, ainsi que les principales techniques de traitement d’image et d’analyse statistique qui leur sont associées. Chaque chapitre comporte une série d'exercices, qui incluent des exemples d'applications dans le cadre de projets de recherche en neurosciences cognitives. Plutôt qu'un ouvrage "spécialiste" qui explique tous les détails sur une technique donnée, ce livre vise à présenter l'ensemble des techniques les plus conventionnelles de manière concise, pour que les lecteurs puissent en apprécier les forces et faiblesses, et le type de recherche pour lequel chaque technique est la plus adaptée.
 
-Le cours est donné principalement par Dr Pierre Bellec, avec des contributions par les auxiliaires d'enseignement, ainsi que de multiples intervenants supplémentaires. Ces notes de cours bénéficient également du retour constructif des étudiants du cours PSY3018 depuis sa création en 2018. Les contributions générales sont présentées ci dessous. Des contributions spécifiques sont listées au sein de chaque chapitre.
+Ce livre a démarré comme une série de notes pour le cours PSY3018, donné au baccalauréat en neurosciences cognitives du département de psychologie de l'Université de Montréal. Le cours est donné principalement par Dr Pierre Bellec, avec des contributions par les auxiliaires d'enseignement, ainsi que de multiples intervenants supplémentaires. Ce livre bénéficie également du retour constructif des étudiants du cours PSY3018 depuis sa création en 2018. Les contributions générales sont présentées ci-dessous. Des contributions spécifiques sont listées au sein de chaque chapitre.
 
 <table>
   <tr>
@@ -110,10 +110,13 @@ Le cours est donné principalement par Dr Pierre Bellec, avec des contributions 
   </tr>
 </table>
 
-Ces notes de cours sont possibles grâce aux projets suivants:
- * [jupyter book](https://jupyterbook.org) est l'outil utilisé pour générer les notes de cours en utilisant plusieurs formats. Ce projet repose lui-même sur l'outil de documentation [sphynx](https://www.sphinx-doc.org).
+Ce livre est dans une large mesure "reproductible": de nombreuses figures sont générées à l'aide de données ouvertes, avec du code qui est intégré dans le libre. Cela est rendu possible grâce aux projets suivants:
+ * [jupyter book](https://jupyterbook.org) est l'outil utilisé pour générer le livre. Ce projet repose lui-même sur l'outil de documentation [sphynx](https://www.sphinx-doc.org).
  * La librairie [nilearn](https://nilearn.github.io/) en [python](https://www.python.org/), notamment pour la partie sur l'IRM structurelle, l'IRM fonctionnelle et les modèles statistiques.
  * La librairie [Dipy](https://dipy.org), notamment pour la partie sur l'IRM de diffusion.
- * Les visualisations d'images cérébrales utilisées dans le cours proviennent en partie de jeux de données publiques.
+ * La librairie [MNE python](https://mne.tools/stable/index.html), notamment pour la partie sur l'imagerie optique.
+ * Les visualisations d'images cérébrales utilisées dans le cours proviennent en partie de jeux de données publiques. L'origine des données est précisée pour chaque figure.
  * Le logo provient du site <a href="https://www.vecteezy.com/free-vector/brain">Brain Vectors by Vecteezy</a>
  * Certaines images du livre ont été obtenues sous droits illimités pour diffusion web et limités pour impression (500k copies) via [shutterstock](https://www.shutterstock.com) par P. Bellec.
+
+ Les auteurs sont très reconnaissants pour l'énorme travail et la générosité des communautés qui créent et maintiennent toutes ces ressources.

--- a/methodes_neurocog/intro.md
+++ b/methodes_neurocog/intro.md
@@ -23,7 +23,7 @@ Ce livre, "Méthodes en neurosciences cognitives", présente les principales tec
 Ce livre est une entrée en matière et est destiné à des lecteurs qui découvrent ces méthodes pour la première fois et souhaitent acquérir des connaissances théoriques sur les bases physiques et physiologiques de ces techniques de neuroimagerie. De plus, il propose une introduction aux principales techniques de traitement d’image et d’analyse statistique qui leur sont associées. Chaque chapitre comporte une série d'exercices qui incluent des exemples d'applications dans le cadre de projets de recherche en neurosciences cognitives.
 
 ```{warning}
-Plutôt qu'un ouvrage "spécialiste" qui explique tous les détails sur une technique donnée, ce livre vise à présenter l'ensemble des techniques les plus conventionnelles en neuroscience cognitive de manière concise, pour que les lecteurs puissent en apprécier les forces et faiblesses, et le type de recherche pour lequel chaque technique est la plus adaptée.
+L'objectif de cet ouvrage n'est pas d'être un outil de référence de type "ouvrage spécialiste" qui explique tous les détails spécifiques liés à une technique donnée. Le but de ce livre est plutôt de présenter un survol de l'ensemble des techniques les plus conventionnelles en neuroscience cognitive de manière concise, pour que les lecteurs puissent en apprécier les forces et faiblesses, ainsi que comprendre comment choisir la technique la plus adaptée à un type de recherche spécifique.
 ```
 
 ## Contributeurs

--- a/methodes_neurocog/intro.md
+++ b/methodes_neurocog/intro.md
@@ -20,7 +20,7 @@ Ce livre, "Méthodes en neurosciences cognitives", présente les principales tec
  * tomographie par émission de positrons,
  * imagerie optique.
 
-Le texte se destine à des lecteurs qui découvrent ces méthodes pour la première fois, et souhaitent acquérir des connaissances théoriques sur les bases physiques et physiologiques de ces techniques de neuroimagerie, ainsi que les principales techniques de traitement d’image et d’analyse statistique qui leur sont associées. Chaque chapitre comporte une série d'exercices, qui incluent des exemples d'applications dans le cadre de projets de recherche en neurosciences cognitives.
+Ce livre est une entrée en matière et est destiné à des lecteurs qui découvrent ces méthodes pour la première fois et souhaitent acquérir des connaissances théoriques sur les bases physiques et physiologiques de ces techniques de neuroimagerie. De plus, il propose une introduction aux principales techniques de traitement d’image et d’analyse statistique qui leur sont associées. Chaque chapitre comporte une série d'exercices qui incluent des exemples d'applications dans le cadre de projets de recherche en neurosciences cognitives.
 
 ```{warning}
 Plutôt qu'un ouvrage "spécialiste" qui explique tous les détails sur une technique donnée, ce livre vise à présenter l'ensemble des techniques les plus conventionnelles en neuroscience cognitive de manière concise, pour que les lecteurs puissent en apprécier les forces et faiblesses, et le type de recherche pour lequel chaque technique est la plus adaptée.

--- a/methodes_neurocog/intro.md
+++ b/methodes_neurocog/intro.md
@@ -122,7 +122,7 @@ Ce livre est dans une large mesure "reproductible": de nombreuses figures sont g
  * La librairie [nilearn](https://nilearn.github.io/) en [python](https://www.python.org/), notamment pour la partie sur l'IRM structurelle, l'IRM fonctionnelle et les modèles statistiques.
  * La librairie [Dipy](https://dipy.org), notamment pour la partie sur l'IRM de diffusion.
  * La librairie [MNE python](https://mne.tools/stable/index.html) est utilisée dans le chapitre portant sur l'imagerie optique.
- * Les visualisations d'images cérébrales utilisées dans le cours proviennent en partie de jeux de données publiques. L'origine des données est précisée pour chaque figure.
+ * Les visualisations d'images cérébrales utilisées dans le cours proviennent en partie de jeux de données publiques. L'origine des données est précisée dans la description de chacune des figures.
  * Le logo provient du site <a href="https://www.vecteezy.com/free-vector/brain">Brain Vectors by Vecteezy</a>
  * Certaines images du livre ont été obtenues sous droits illimités pour diffusion web et limités pour impression (500k copies) via [shutterstock](https://www.shutterstock.com) par P. Bellec.
 

--- a/methodes_neurocog/intro.md
+++ b/methodes_neurocog/intro.md
@@ -117,7 +117,7 @@ Le développement de ce livre a démarré afin de servir d'outil de référence 
 </table>
 
 ## Remerciements
-Ce livre est dans une large mesure "reproductible": de nombreuses figures sont générées à l'aide de données ouvertes, avec du code qui fait parti du livre. Cette technologie est rendue possible grâce aux projets suivants:
+Ce livre est dans une large mesure "reproductible": de nombreuses figures sont générées à l'aide de données ouvertes, avec du code accessible à même le livre. Cette technologie est rendue possible grâce aux projets suivants:
  * [jupyter book](https://jupyterbook.org) est l'outil utilisé pour générer le livre. Ce projet repose lui-même sur l'outil de documentation [sphynx](https://www.sphinx-doc.org).
  * La librairie [nilearn](https://nilearn.github.io/) en [python](https://www.python.org/), notamment pour la partie sur l'IRM structurelle, l'IRM fonctionnelle et les modèles statistiques.
  * La librairie [Dipy](https://dipy.org), notamment pour la partie sur l'IRM de diffusion.

--- a/methodes_neurocog/intro.md
+++ b/methodes_neurocog/intro.md
@@ -121,7 +121,7 @@ Ce livre est dans une large mesure "reproductible": de nombreuses figures sont g
  * [jupyter book](https://jupyterbook.org) est l'outil utilisé pour générer le livre. Ce projet repose lui-même sur l'outil de documentation [sphinx](https://www.sphinx-doc.org).
  * La librairie [nilearn](https://nilearn.github.io/) en [python](https://www.python.org/), notamment pour la partie sur l'IRM structurelle, l'IRM fonctionnelle et les modèles statistiques.
  * La librairie [Dipy](https://dipy.org), notamment pour la partie sur l'IRM de diffusion.
- * La librairie [MNE python](https://mne.tools/stable/index.html), notamment pour la partie sur l'imagerie optique.
+ * La librairie [MNE python](https://mne.tools/stable/index.html) est utilisée dans le chapitre portant sur l'imagerie optique.
  * Les visualisations d'images cérébrales utilisées dans le cours proviennent en partie de jeux de données publiques. L'origine des données est précisée pour chaque figure.
  * Le logo provient du site <a href="https://www.vecteezy.com/free-vector/brain">Brain Vectors by Vecteezy</a>
  * Certaines images du livre ont été obtenues sous droits illimités pour diffusion web et limités pour impression (500k copies) via [shutterstock](https://www.shutterstock.com) par P. Bellec.

--- a/methodes_neurocog/intro.md
+++ b/methodes_neurocog/intro.md
@@ -15,7 +15,7 @@ kernelspec:
 
 # Introduction
 
-Ce livre "Méthodes en neurosciences cognitives" présente les principales techniques de neuroimagerie pour étudier la cognition chez l'humain (et l'animal), disposant d'une bonne résolution spatiale:
+Ce livre, "Méthodes en neurosciences cognitives", présente les principales techniques de neuroimagerie utilisées pour étudier la cognition chez l'humain (et l'animal) et disposant d'une bonne résolution spatiale:
  * résonance magnétique (anatomique, fonctionnelle, et de diffusion),
  * tomographie par émission de positrons,
  * imagerie optique.

--- a/methodes_neurocog/intro.md
+++ b/methodes_neurocog/intro.md
@@ -118,7 +118,7 @@ Le développement de ce livre a démarré afin de servir d'outil de référence 
 
 ## Remerciements
 Ce livre est dans une large mesure "reproductible": de nombreuses figures sont générées à l'aide de données ouvertes, avec du code accessible à même le livre. Cette technologie est rendue possible grâce aux projets suivants:
- * [jupyter book](https://jupyterbook.org) est l'outil utilisé pour générer le livre. Ce projet repose lui-même sur l'outil de documentation [sphynx](https://www.sphinx-doc.org).
+ * [jupyter book](https://jupyterbook.org) est l'outil utilisé pour générer le livre. Ce projet repose lui-même sur l'outil de documentation [sphinx](https://www.sphinx-doc.org).
  * La librairie [nilearn](https://nilearn.github.io/) en [python](https://www.python.org/), notamment pour la partie sur l'IRM structurelle, l'IRM fonctionnelle et les modèles statistiques.
  * La librairie [Dipy](https://dipy.org), notamment pour la partie sur l'IRM de diffusion.
  * La librairie [MNE python](https://mne.tools/stable/index.html), notamment pour la partie sur l'imagerie optique.

--- a/methodes_neurocog/intro.md
+++ b/methodes_neurocog/intro.md
@@ -28,7 +28,7 @@ L'objectif de cet ouvrage n'est pas d'être un outil de référence de type "ouv
 
 ## Contributeurs
 
-Ce livre a démarré comme une série de notes pour le cours PSY3018, donné au baccalauréat en neurosciences cognitives du département de psychologie de l'Université de Montréal. Le cours est donné principalement par Dr Pierre Bellec, avec des contributions par les auxiliaires d'enseignement, ainsi que de multiples intervenants supplémentaires. Ce livre bénéficie également du retour constructif des étudiants du cours PSY3018 depuis sa création en 2018. Les contributions générales sont présentées ci-dessous. Des contributions spécifiques sont listées au sein de chaque chapitre.
+Le développement de ce livre a démarré afin de servir d'outil de référence pour le cours PSY3018, donné au baccalauréat en neurosciences cognitives de l'Université de Montréal. Le cours est donné principalement par le Dr Pierre Bellec, avec la contribution des auxiliaires d'enseignement ainsi que de multiples intervenants supplémentaires. Ce livre bénéficie également du retour constructif des étudiants ayant suivi le cours PSY3018 depuis sa création en 2018. Les contributions générales sont présentées ci-dessous. Des contributions spécifiques sont listées au sein de chaque chapitre.
 
 <table>
   <tr>


### PR DESCRIPTION
this should fix #72 : 
 * switch to "livre" instead of "note de cours"
 * explain a bit who is the intended audience, and how this book differs from more specialized, modality-specific books.
 * improve a bit the formatting. 